### PR TITLE
Refactor matchers to use a MatcherMeta

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -83,7 +83,7 @@ impl Display for FluxError {
             f,
             "FluxError at {} with {} description \"{}\"",
             self.location,
-            match *self.matcher_name {
+            match &*self.matcher_name {
                 Some(m) => format!("matcher named `{}`", m),
                 None => "no matcher".into(),
             },

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,7 +36,7 @@ impl FluxError {
         FluxError {
             description: ErrorMessage::Constant(description),
             location,
-            matcher_name: Rc::new(RefCell::new(None)),
+            matcher_name: Rc::new(None),
             backtrace: Backtrace::capture(),
         }
     }
@@ -58,7 +58,7 @@ impl FluxError {
         FluxError {
             description: ErrorMessage::Dynamic(description),
             location,
-            matcher_name: Rc::new(RefCell::new(None)),
+            matcher_name: Rc::new(None),
             backtrace: Backtrace::capture(),
         }
     }
@@ -83,7 +83,7 @@ impl Display for FluxError {
             f,
             "FluxError at {} with {} description \"{}\"",
             self.location,
-            match &self.matcher_name.as_ref().borrow().deref() {
+            match *self.matcher_name {
                 Some(m) => format!("matcher named `{}`", m),
                 None => "no matcher".into(),
             },

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -66,7 +66,7 @@ impl Lexer {
     }
 
     fn get_cull_strat(&self, token: &Token) -> CullStrategy {
-        if token.matcher_name.borrow().is_none() {
+        if token.matcher_name.is_none() {
             return self.unnamed_rule;
         }
         if token.range.is_empty() && !self.retain_empty {

--- a/src/matchers/choice.rs
+++ b/src/matchers/choice.rs
@@ -3,7 +3,7 @@ use crate::error::{FluxError, Result};
 use crate::tokens::Token;
 use std::{cell::RefCell, rc::Rc};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ChoiceMatcher {
     meta: MatcherMeta,
     min_length: RefCell<Option<usize>>,

--- a/src/matchers/choice.rs
+++ b/src/matchers/choice.rs
@@ -1,37 +1,36 @@
-use super::{Matcher, MatcherName, MatcherRef};
+use super::{Matcher, MatcherName, MatcherRef, MatcherMeta};
 use crate::error::{FluxError, Result};
 use crate::tokens::Token;
 use std::{cell::RefCell, rc::Rc};
 
 #[derive(Debug)]
 pub struct ChoiceMatcher {
-    name: MatcherName,
+    meta: MatcherMeta,
     min_length: RefCell<Option<usize>>,
     children: Vec<RefCell<MatcherRef>>,
-    id: RefCell<usize>,
 }
 
 impl ChoiceMatcher {
-    pub fn new(children: Vec<RefCell<MatcherRef>>) -> ChoiceMatcher {
+    pub fn new(meta: MatcherMeta, children: Vec<RefCell<MatcherRef>>) -> ChoiceMatcher {
         ChoiceMatcher {
-            name: Rc::new(RefCell::new(None)),
+            meta,
             min_length: RefCell::new(None),
             children,
-            id: RefCell::new(0),
         }
     }
 }
 
 impl Matcher for ChoiceMatcher {
+    with_meta!();
     fn apply(&self, source: Rc<Vec<char>>, pos: usize) -> Result<Token> {
         for child in &self.children {
             if let Ok(token) = child.borrow().apply(source.clone(), pos) {
                 return Ok(Token {
-                    matcher_name: self.name.clone(),
+                    matcher_name: self.get_name().clone(),
                     range: token.range.clone(),
                     children: vec![token],
                     source,
-                    matcher_id: *self.id.borrow(),
+                    matcher_id: self.id(),
                 });
             }
         }
@@ -39,7 +38,7 @@ impl Matcher for ChoiceMatcher {
         Err(FluxError::new_matcher(
             "in ChoiceMatcher all children failed",
             pos,
-            self.name.clone(),
+            self.get_name().clone(),
         ))
     }
 
@@ -58,18 +57,11 @@ impl Matcher for ChoiceMatcher {
         }
     }
 
-    fn get_name(&self) -> MatcherName {
-        self.name.clone()
-    }
-
-    fn set_name(&self, new_name: String) {
-        self.name.replace(Some(new_name));
-    }
     fn children(&self) -> Option<&Vec<RefCell<MatcherRef>>> {
         Some(&self.children)
     }
 
-    fn id(&self) -> &RefCell<usize> {
-        &self.id
+    fn meta(&self) -> &MatcherMeta {
+        &self.meta
     }
 }

--- a/src/matchers/eof.rs
+++ b/src/matchers/eof.rs
@@ -2,7 +2,7 @@ use super::{Matcher, MatcherMeta, MatcherName};
 use crate::{error::FluxError, error::Result, tokens::Token};
 use std::{cell::RefCell, rc::Rc};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct EofMatcher {
     meta: MatcherMeta,
 }

--- a/src/matchers/eof.rs
+++ b/src/matchers/eof.rs
@@ -1,37 +1,34 @@
-use super::{Matcher, MatcherName};
+use super::{Matcher, MatcherMeta, MatcherName};
 use crate::{error::FluxError, error::Result, tokens::Token};
 use std::{cell::RefCell, rc::Rc};
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct EofMatcher {
-    name: MatcherName,
-    id: RefCell<usize>,
+    meta: MatcherMeta,
 }
 
 impl EofMatcher {
-    pub fn new() -> EofMatcher {
-        EofMatcher {
-            name: Rc::new(RefCell::new(None)),
-            id: RefCell::new(0),
-        }
+    pub fn new(meta: MatcherMeta) -> EofMatcher {
+        EofMatcher { meta }
     }
 }
 
 impl Matcher for EofMatcher {
+    with_meta!();
     fn apply(&self, source: Rc<Vec<char>>, pos: usize) -> Result<Token> {
         if pos == source.len() {
             Ok(Token {
-                matcher_name: self.name.clone(),
+                matcher_name: self.get_name().clone(),
                 children: Vec::new(),
                 source,
                 range: (pos..pos),
-                matcher_id: *self.id.borrow(),
+                matcher_id: self.id(),
             })
         } else {
             Err(FluxError::new_matcher(
                 "expected end of file",
                 pos,
-                self.name.clone(),
+                self.get_name().clone(),
             ))
         }
     }
@@ -40,15 +37,7 @@ impl Matcher for EofMatcher {
         0
     }
 
-    fn get_name(&self) -> MatcherName {
-        self.name.clone()
-    }
-
-    fn set_name(&self, name: String) {
-        self.name.replace(Some(name));
-    }
-
-    fn id(&self) -> &RefCell<usize> {
-        &self.id
+    fn meta(&self) -> &MatcherMeta {
+        &self.meta
     }
 }

--- a/src/matchers/inverted.rs
+++ b/src/matchers/inverted.rs
@@ -2,7 +2,7 @@ use super::{Matcher, MatcherChildren, MatcherName, MatcherRef, MatcherMeta};
 use crate::{error::FluxError, error::Result, tokens::Token};
 use std::{cell::RefCell, rc::Rc, vec};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct InvertedMatcher {
     meta: MatcherMeta,
     child: MatcherChildren,

--- a/src/matchers/inverted.rs
+++ b/src/matchers/inverted.rs
@@ -1,34 +1,33 @@
-use super::{Matcher, MatcherChildren, MatcherName, MatcherRef};
+use super::{Matcher, MatcherChildren, MatcherName, MatcherRef, MatcherMeta};
 use crate::{error::FluxError, error::Result, tokens::Token};
 use std::{cell::RefCell, rc::Rc, vec};
 
 #[derive(Debug)]
 pub struct InvertedMatcher {
-    name: MatcherName,
+    meta: MatcherMeta,
     child: MatcherChildren,
-    id: RefCell<usize>,
 }
 
 impl InvertedMatcher {
-    pub fn new(child: MatcherRef) -> Self {
+    pub fn new(meta: MatcherMeta, child: MatcherRef) -> Self {
         Self {
-            name: Rc::new(RefCell::new(None)),
+            meta,
             child: vec![RefCell::new(child)],
-            id: RefCell::new(0),
         }
     }
 }
 
 impl Matcher for InvertedMatcher {
+    with_meta!();
     fn apply(&self, source: Rc<Vec<char>>, pos: usize) -> Result<Token> {
         match self.child[0].borrow().apply(source.clone(), pos) {
-            Ok(_) => Err(FluxError::new_matcher("unexpected", pos, self.name.clone())),
+            Ok(_) => Err(FluxError::new_matcher("unexpected", pos, self.get_name().clone())),
             Err(_) => Ok(Token {
                 children: vec![],
-                matcher_name: self.name.clone(),
+                matcher_name: self.get_name().clone(),
                 source,
                 range: pos..pos,
-                matcher_id: *self.id.borrow(),
+                matcher_id: self.id(),
             }),
         }
     }
@@ -37,19 +36,11 @@ impl Matcher for InvertedMatcher {
         0
     }
 
-    fn get_name(&self) -> MatcherName {
-        self.name.clone()
-    }
-
-    fn set_name(&self, new_name: String) {
-        self.name.replace(Some(new_name));
-    }
-
     fn children(&self) -> Option<&super::MatcherChildren> {
         Some(&self.child)
     }
 
-    fn id(&self) -> &RefCell<usize> {
-        &self.id
+    fn meta(&self) -> &MatcherMeta {
+        &self.meta
     }
 }

--- a/src/matchers/mod.rs
+++ b/src/matchers/mod.rs
@@ -9,7 +9,7 @@ pub type MatcherChildren = Vec<RefCell<MatcherRef>>;
 pub type MatcherName = Rc<Option<String>>;
 
 #[derive(Clone, Debug)]
-pub(crate) struct MatcherMeta {
+pub struct MatcherMeta {
     pub name: MatcherName,
     pub id: usize,
 }
@@ -20,7 +20,7 @@ macro_rules! with_meta {
         fn with_meta(&self, meta: MatcherMeta) -> crate::matchers::MatcherRef {
             Rc::new(Self {
                 meta,
-                ..*self
+                ..self.clone()
             })
         }
     }
@@ -42,6 +42,7 @@ pub trait Matcher: Debug {
     fn apply(&self, source: Rc<Vec<char>>, pos: usize) -> Result<Token>;
     fn min_length(&self) -> usize;
     fn meta(&self) -> &MatcherMeta;
+    fn with_meta(&self, meta: MatcherMeta) -> MatcherRef;
 
     fn children(&self) -> Option<&MatcherChildren> {
         None
@@ -57,12 +58,6 @@ pub trait Matcher: Debug {
 
     fn id(&self) -> usize {
         self.meta().id
-    }
-
-    fn with_meta(&self, meta: MatcherMeta) -> MatcherRef;
-
-    fn reset_meta(&self) -> MatcherRef {
-        self.with_meta(Default::default())
     }
 }
 

--- a/src/matchers/mod.rs
+++ b/src/matchers/mod.rs
@@ -6,19 +6,63 @@ use std::rc::Rc;
 
 pub type MatcherRef = Rc<dyn Matcher>;
 pub type MatcherChildren = Vec<RefCell<MatcherRef>>;
-pub type MatcherName = Rc<RefCell<Option<String>>>;
+pub type MatcherName = Rc<Option<String>>;
+
+#[derive(Clone, Debug)]
+pub(crate) struct MatcherMeta {
+    pub name: MatcherName,
+    pub id: usize,
+}
+
+#[macro_export]
+macro_rules! with_meta {
+    () => {
+        fn with_meta(&self, meta: MatcherMeta) -> crate::matchers::MatcherRef {
+            Rc::new(Self {
+                meta,
+                ..*self
+            })
+        }
+    }
+}
+
+impl MatcherMeta {
+    pub fn new(name: Option<String>, id: usize) -> MatcherMeta {
+        MatcherMeta { name: Rc::new(name), id }
+    }
+}
+
+impl Default for MatcherMeta {
+    fn default() -> Self {
+        MatcherMeta { name: Rc::new(None), id: 0 }
+    }
+}
 
 pub trait Matcher: Debug {
     fn apply(&self, source: Rc<Vec<char>>, pos: usize) -> Result<Token>;
     fn min_length(&self) -> usize;
-    fn get_name(&self) -> MatcherName;
-    fn set_name(&self, new_name: String);
-    fn id(&self) -> &RefCell<usize>;
+    fn meta(&self) -> &MatcherMeta;
+
     fn children(&self) -> Option<&MatcherChildren> {
         None
     }
+
     fn is_placeholder(&self) -> bool {
         false
+    }
+
+    fn get_name(&self) -> &Rc<Option<String>> {
+        &self.meta().name
+    }
+
+    fn id(&self) -> usize {
+        self.meta().id
+    }
+
+    fn with_meta(&self, meta: MatcherMeta) -> MatcherRef;
+
+    fn reset_meta(&self) -> MatcherRef {
+        self.with_meta(Default::default())
     }
 }
 

--- a/src/matchers/placeholder.rs
+++ b/src/matchers/placeholder.rs
@@ -1,23 +1,20 @@
-use super::{Matcher, MatcherName};
+use super::{Matcher, MatcherMeta};
 use crate::{error::Result, tokens::Token};
-use std::{cell::RefCell, rc::Rc};
+use std::rc::Rc;
 
 #[derive(Debug)]
 pub struct PlaceholderMatcher {
-    name: MatcherName,
-    id: RefCell<usize>,
+    meta: MatcherMeta,
 }
 
 impl PlaceholderMatcher {
-    pub fn new(name: String) -> PlaceholderMatcher {
-        PlaceholderMatcher {
-            name: Rc::new(RefCell::new(Some(name))),
-            id: RefCell::new(0),
-        }
+    pub fn new(meta: MatcherMeta) -> PlaceholderMatcher {
+        PlaceholderMatcher { meta }
     }
 }
 
 impl Matcher for PlaceholderMatcher {
+    with_meta!();
     fn apply(&self, _: Rc<Vec<char>>, _: usize) -> Result<Token> {
         unreachable!()
     }
@@ -26,19 +23,11 @@ impl Matcher for PlaceholderMatcher {
         unreachable!()
     }
 
-    fn get_name(&self) -> MatcherName {
-        self.name.clone()
-    }
-
-    fn set_name(&self, _: String) {
-        unreachable!()
-    }
-
     fn is_placeholder(&self) -> bool {
         true
     }
 
-    fn id(&self) -> &RefCell<usize> {
-        &self.id
+    fn meta(&self) -> &MatcherMeta {
+        &self.meta
     }
 }

--- a/src/matchers/placeholder.rs
+++ b/src/matchers/placeholder.rs
@@ -2,7 +2,7 @@ use super::{Matcher, MatcherMeta};
 use crate::{error::Result, tokens::Token};
 use std::rc::Rc;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct PlaceholderMatcher {
     meta: MatcherMeta,
 }

--- a/src/matchers/repeating.rs
+++ b/src/matchers/repeating.rs
@@ -1,29 +1,28 @@
-use super::{Matcher, MatcherChildren, MatcherName, MatcherRef};
+use super::{Matcher, MatcherChildren, MatcherName, MatcherRef, MatcherMeta};
 use crate::{error::FluxError, error::Result, tokens::Token};
 use std::{cell::RefCell, rc::Rc};
 
 #[derive(Debug)]
 pub struct RepeatingMatcher {
-    name: MatcherName,
+    meta: MatcherMeta,
     min: usize,
     max: usize,
     child: MatcherChildren,
-    id: RefCell<usize>,
 }
 
 impl RepeatingMatcher {
-    pub fn new(min: usize, max: usize, child: MatcherRef) -> Self {
+    pub fn new(meta: MatcherMeta, min: usize, max: usize, child: MatcherRef) -> Self {
         Self {
-            name: Rc::new(RefCell::new(None)),
+            meta,
             min,
             max,
             child: vec![RefCell::new(child)],
-            id: RefCell::new(0),
         }
     }
 }
 
 impl Matcher for RepeatingMatcher {
+    with_meta!();
     fn apply(&self, source: Rc<Vec<char>>, pos: usize) -> Result<Token> {
         let mut children: Vec<Token> = Vec::new();
 
@@ -40,14 +39,14 @@ impl Matcher for RepeatingMatcher {
         }
 
         if children.len() < self.min {
-            Err(FluxError::new_matcher("expected", pos, self.name.clone()))
+            Err(FluxError::new_matcher("expected", pos, self.get_name().clone()))
         } else {
             Ok(Token {
                 range: (pos..cursor),
                 children,
-                matcher_name: self.name.clone(),
+                matcher_name: self.get_name().clone(),
                 source,
-                matcher_id: *self.id.borrow(),
+                matcher_id: self.id(),
             })
         }
     }
@@ -60,15 +59,7 @@ impl Matcher for RepeatingMatcher {
         Some(&self.child)
     }
 
-    fn get_name(&self) -> MatcherName {
-        self.name.clone()
-    }
-
-    fn set_name(&self, new_name: String) {
-        self.name.replace(Some(new_name));
-    }
-
-    fn id(&self) -> &RefCell<usize> {
-        &self.id
+    fn meta(&self) -> &MatcherMeta {
+        &self.meta
     }
 }

--- a/src/matchers/repeating.rs
+++ b/src/matchers/repeating.rs
@@ -2,7 +2,7 @@ use super::{Matcher, MatcherChildren, MatcherName, MatcherRef, MatcherMeta};
 use crate::{error::FluxError, error::Result, tokens::Token};
 use std::{cell::RefCell, rc::Rc};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct RepeatingMatcher {
     meta: MatcherMeta,
     min: usize,

--- a/src/matchers/string.rs
+++ b/src/matchers/string.rs
@@ -1,22 +1,20 @@
-use super::{Matcher, MatcherName};
+use super::{Matcher, MatcherMeta};
 use crate::{error::FluxError, error::Result, tokens::Token};
-use std::{cell::RefCell, rc::Rc};
+use std::rc::Rc;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct StringMatcher {
-    name: MatcherName,
+    meta: MatcherMeta,
     to_match: Vec<char>,
     case_sensitive: bool,
-    id: RefCell<usize>,
 }
 
 impl StringMatcher {
-    pub fn new(to_match: String, case_sensitive: bool) -> Self {
+    pub fn new(meta: MatcherMeta, to_match: String, case_sensitive: bool) -> Self {
         Self {
-            name: Rc::new(RefCell::new(None)),
+            meta,
             to_match: to_match.chars().collect(),
             case_sensitive,
-            id: RefCell::new(0),
         }
     }
 
@@ -39,14 +37,14 @@ impl Matcher for StringMatcher {
 
         if zip.len() == self.to_match.len() && zip.all(|(a, b)| self.char_matches(a, b)) {
             Ok(Token {
-                matcher_name: self.name.clone(),
+                matcher_name: self.get_name().clone(),
                 children: vec![],
                 source,
                 range: pos..pos + self.to_match.len(),
-                matcher_id: *self.id.borrow(),
+                matcher_id: self.id(),
             })
         } else {
-            Err(FluxError::new_matcher("expected", pos, self.name.clone()))
+            Err(FluxError::new_matcher("expected", pos, self.get_name().clone()))
         }
     }
 
@@ -54,15 +52,14 @@ impl Matcher for StringMatcher {
         self.to_match.len()
     }
 
-    fn get_name(&self) -> MatcherName {
-        self.name.clone()
+    fn meta(&self) -> &MatcherMeta {
+        &self.meta
     }
 
-    fn set_name(&self, new_name: String) {
-        self.name.replace(Some(new_name));
-    }
-
-    fn id(&self) -> &RefCell<usize> {
-        &self.id
+    fn with_meta(&self, meta: MatcherMeta) -> super::MatcherRef {
+        Rc::new(Self {
+            meta,
+            ..self.clone()
+        })
     }
 }

--- a/src/matchers/string.rs
+++ b/src/matchers/string.rs
@@ -28,6 +28,7 @@ impl StringMatcher {
 }
 
 impl Matcher for StringMatcher {
+    with_meta!();
     fn apply(&self, source: Rc<Vec<char>>, pos: usize) -> Result<Token> {
         let mut zip = self
             .to_match
@@ -54,12 +55,5 @@ impl Matcher for StringMatcher {
 
     fn meta(&self) -> &MatcherMeta {
         &self.meta
-    }
-
-    fn with_meta(&self, meta: MatcherMeta) -> super::MatcherRef {
-        Rc::new(Self {
-            meta,
-            ..self.clone()
-        })
     }
 }

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -20,12 +20,7 @@ impl Token {
     }
 
     pub fn get_name(&self) -> Option<String> {
-        self.matcher_name
-            .deref()
-            .borrow()
-            .deref()
-            .as_ref()
-            .map(String::from)
+        *self.matcher_name
     }
 }
 
@@ -34,7 +29,7 @@ impl Debug for Token {
         let mut debug = f.debug_struct("Token");
         debug.field(
             "name",
-            &self.matcher_name.borrow().clone().unwrap_or_default(),
+            &*self.matcher_name,
         );
         debug.field("match", &self.get_match());
         debug.field("range", &self.range);

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -19,8 +19,8 @@ impl Token {
         self.source[self.range.clone()].iter().collect()
     }
 
-    pub fn get_name(&self) -> Option<String> {
-        *self.matcher_name
+    pub fn get_name(&self) -> &Option<String> {
+        &*self.matcher_name
     }
 }
 


### PR DESCRIPTION
- MatcherMeta holds the name and ID of a matcher
- The name and ID are no longer mutable