### PR TITLE
Fix template IDs

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -14,7 +14,7 @@ fn main() {
     };
 
     lexer.add_rule_for_names(
-        vec!["sep", "lineSep", "alpha", "alphanum", "break", "newLine"]
+        vec!["sep"]
             .iter()
             .map(ToString::to_string)
             .collect(),

--- a/examples/test_fender.fndr
+++ b/examples/test_fender.fndr
@@ -1,7 +1,1 @@
-fn f(x) = x * 2
-
-fn f(x: int) {
-   x * 2
-}
-
-struct Person {name: str, age: int}
+1 + 1

--- a/src/bnf.rs
+++ b/src/bnf.rs
@@ -154,12 +154,12 @@ impl BNFParserState {
         if self.check_str("//") {
             self.consume_comment();
         }
-        if !transparent {
-            matcher = matcher.with_meta(meta);
-        }
         if let Some(params) = template_params {
             Ok(Some(ParseLineResult::Template(matcher, params, name)))
         } else {
+            if !transparent {
+                matcher = matcher.with_meta(meta);
+            }
             Ok(Some(ParseLineResult::Rule(matcher, name)))
         }
     }


### PR DESCRIPTION
Fixes a bug that was causing template matchers to break named lexer rules for culling tokens