### PR TITLE
Change tokenize to take impl AsRef<str> instead of impl ToString and add tokenize_with to Lexer

### DIFF
--- a/src/bnf.rs
+++ b/src/bnf.rs
@@ -136,7 +136,7 @@ impl BNFParserState {
         let root = rule_map.get("root").ok_or_else(|| {
             FluxError::new("No root matcher specified", 0, Some(self.source.clone()))
         })?;
-        Ok(Lexer::new(root.clone(), id_map))
+        Ok(Lexer::new(root.clone(), id_map, rules))
     }
 
     fn parse_rule(&mut self, id: usize) -> Result<Option<ParseLineResult>> {

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -25,17 +25,19 @@ pub struct Lexer {
     retain_empty: bool,
     unnamed_rule: CullStrategy,
     names: HashMap<String, usize>,
+    matchers: Vec<MatcherRef>,
     named_rules: Vec<CullStrategy>,
 }
 
 impl Lexer {
-    pub fn new(root: MatcherRef, names: HashMap<String, usize>) -> Lexer {
+    pub fn new(root: MatcherRef, names: HashMap<String, usize>, matchers: Vec<MatcherRef>) -> Lexer {
         Lexer {
             root,
             retain_empty: false,
             unnamed_rule: CullStrategy::LiftChildren,
             named_rules: vec![CullStrategy::None; names.len() + 1],
             names,
+            matchers
         }
     }
 
@@ -56,10 +58,19 @@ impl Lexer {
     }
 
     pub fn tokenize(&self, input: impl AsRef<str>) -> Result<Token> {
+        self.do_tokenize(self.root.clone(), input)
+    }
+
+    pub fn tokenize_with(&self, matcher: &str, input: impl AsRef<str>) -> Result<Token> {
+        let matcher = self.matchers[self.names[matcher] - 1].clone();
+        self.do_tokenize(matcher, input)
+    }
+
+    fn do_tokenize(&self, root: MatcherRef, input: impl AsRef<str>) -> Result<Token> {
         let input = input.as_ref();
         let source = Arc::new(input.chars().collect::<Vec<char>>());
         let pos = 0;
-        let token = self.root.apply(source.clone(), pos, 0)?;
+        let token = root.apply(source.clone(), pos, 0)?;
         if token.range.len() < input.len() {
             if let Some(err) = token.failure {
                 return Err(err);

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -55,8 +55,8 @@ impl Lexer {
         }
     }
 
-    pub fn tokenize(&self, input: impl ToString) -> Result<Token> {
-        let input = input.to_string();
+    pub fn tokenize(&self, input: impl AsRef<str>) -> Result<Token> {
+        let input = input.as_ref();
         let source = Arc::new(input.chars().collect::<Vec<char>>());
         let pos = 0;
         let token = self.root.apply(source.clone(), pos, 0)?;

--- a/src/tests/bnf/numbers.bnf
+++ b/src/tests/bnf/numbers.bnf
@@ -1,5 +1,5 @@
 root ::= number
 number ::= decimal | int
-digit ::= [0-9]+
+digit ::= [0-9]
 int ::= "-"? digit+
 decimal ::= "-"? int "." int

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -138,3 +138,16 @@ fn template_test() {
     lexer.tokenize("[1, 2]").unwrap();
     lexer.tokenize("[1, 2").unwrap_err();
 }
+
+#[test]
+fn alt_root_test() {
+    let lexer = bnf::parse(include_str!("bnf/numbers.bnf")).unwrap();
+    lexer.tokenize("4").unwrap();
+    lexer.tokenize_with("root", "4").unwrap();
+    lexer.tokenize_with("number", "4").unwrap();
+    lexer.tokenize_with("decimal", "4.0").unwrap();
+    lexer.tokenize_with("int", "4.0").unwrap_err();
+    lexer.tokenize_with("int", "4").unwrap();
+    lexer.tokenize_with("digit", "4").unwrap();
+    lexer.tokenize_with("digit", "40").unwrap_err();
+}


### PR DESCRIPTION
Making it take an AsRef<str> saves a string copy, and tokenize_with allows you to specify an alternative root token to parse the input with in case you want to parse some specific thing. This makes it more flexible and allows you to build on top of it more easily.