### PR TITLE
Use Vec::with_capacity where possible

### DIFF
--- a/src/matchers/char_range.rs
+++ b/src/matchers/char_range.rs
@@ -31,7 +31,7 @@ impl Matcher for CharRangeMatcher {
         match source.get(pos) {
             Some(c) if self.check_char(*c) => Ok(Token {
                 matcher_name: self.name().clone(),
-                children: vec![],
+                children: Vec::with_capacity(0),
                 source,
                 range: pos..pos + 1,
                 matcher_id: self.id(),

--- a/src/matchers/char_set.rs
+++ b/src/matchers/char_set.rs
@@ -28,7 +28,7 @@ impl Matcher for CharSetMatcher {
     fn apply(&self, source: Arc<Vec<char>>, pos: usize, depth: usize) -> Result<Token> {
         match source.get(pos) {
             Some(c) if self.check_char(c) => Ok(Token {
-                children: vec![],
+                children: Vec::with_capacity(0),
                 matcher_name: self.name().clone(),
                 range: pos..pos + 1,
                 source,

--- a/src/matchers/eof.rs
+++ b/src/matchers/eof.rs
@@ -19,7 +19,7 @@ impl Matcher for EofMatcher {
         if pos == source.len() {
             Ok(Token {
                 matcher_name: self.name().clone(),
-                children: Vec::new(),
+                children: Vec::with_capacity(0),
                 source,
                 range: (pos..pos),
                 matcher_id: self.id(),

--- a/src/matchers/inverted.rs
+++ b/src/matchers/inverted.rs
@@ -32,7 +32,7 @@ impl Matcher for InvertedMatcher {
                 Some(source),
             )),
             Err(err) => Ok(Token {
-                children: vec![],
+                children: Vec::with_capacity(0),
                 matcher_name: self.name().clone(),
                 source,
                 range: pos..pos,

--- a/src/matchers/list.rs
+++ b/src/matchers/list.rs
@@ -20,7 +20,7 @@ impl ListMatcher {
 impl Matcher for ListMatcher {
     impl_meta!();
     fn apply(&self, source: Arc<Vec<char>>, pos: usize, depth: usize) -> Result<Token> {
-        let mut children: Vec<Token> = Vec::new();
+        let mut children: Vec<Token> = Vec::with_capacity(self.children.get().len());
         let mut cursor = pos;
         let mut failures = Vec::new();
         for child in &*self.children.get() {

--- a/src/matchers/repeating.rs
+++ b/src/matchers/repeating.rs
@@ -24,7 +24,7 @@ impl RepeatingMatcher {
 impl Matcher for RepeatingMatcher {
     impl_meta!();
     fn apply(&self, source: Arc<Vec<char>>, pos: usize, depth: usize) -> Result<Token> {
-        let mut children: Vec<Token> = Vec::new();
+        let mut children: Vec<Token> = Vec::with_capacity(self.min);
 
         let child = &self.child.get()[0];
         let mut cursor = pos;

--- a/src/matchers/string.rs
+++ b/src/matchers/string.rs
@@ -37,7 +37,7 @@ impl Matcher for StringMatcher {
         {
             Ok(Token {
                 matcher_name: self.name().clone(),
-                children: vec![],
+                children: Vec::with_capacity(0),
                 source,
                 range: pos..pos + self.to_match.len(),
                 matcher_id: self.id(),


### PR DESCRIPTION
`Vec::with_capacity(0)` does not perform a heap allocation, so this should provide a slight performance improvement for matchers that never match any children