### PR TITLE
Repeating fix

### DIFF
--- a/src/matchers.rs
+++ b/src/matchers.rs
@@ -1,4 +1,3 @@
-use std::backtrace::Backtrace;
 use std::ops::Range;
 use std::{ops::RangeInclusive, sync::Arc};
 


### PR DESCRIPTION
Make repeating matchers stop matching if their child returns a zero-length match (since trying to continue applying it will result in another zero-length match, entering an infinite loop)